### PR TITLE
Remove unnecessary touch command from control scripts

### DIFF
--- a/pattern-1/bosh-release/jobs/wso2is_1/templates/ctl.erb
+++ b/pattern-1/bosh-release/jobs/wso2is_1/templates/ctl.erb
@@ -35,7 +35,6 @@ mkdir -p ${run_dir} ${log_dir}
 chown -R vcap:vcap ${run_dir} ${log_dir}
 
 debug_log=${log_dir}/${wso2_product}.log
-touch ${debug_log}
 
 function log_debug() {
   echo `date` $1 >> ${debug_log}

--- a/pattern-1/bosh-release/jobs/wso2is_2/templates/ctl.erb
+++ b/pattern-1/bosh-release/jobs/wso2is_2/templates/ctl.erb
@@ -35,7 +35,6 @@ mkdir -p ${run_dir} ${log_dir}
 chown -R vcap:vcap ${run_dir} ${log_dir}
 
 debug_log=${log_dir}/${wso2_product}.log
-touch ${debug_log}
 
 function log_debug() {
   echo `date` $1 >> ${debug_log}

--- a/pattern-2/bosh-release/jobs/wso2is_1/templates/ctl.erb
+++ b/pattern-2/bosh-release/jobs/wso2is_1/templates/ctl.erb
@@ -35,7 +35,6 @@ mkdir -p ${run_dir} ${log_dir}
 chown -R vcap:vcap ${run_dir} ${log_dir}
 
 debug_log=${log_dir}/${wso2_product}.log
-touch ${debug_log}
 
 function log_debug() {
   echo `date` $1 >> ${debug_log}

--- a/pattern-2/bosh-release/jobs/wso2is_2/templates/ctl.erb
+++ b/pattern-2/bosh-release/jobs/wso2is_2/templates/ctl.erb
@@ -35,7 +35,6 @@ mkdir -p ${run_dir} ${log_dir}
 chown -R vcap:vcap ${run_dir} ${log_dir}
 
 debug_log=${log_dir}/${wso2_product}.log
-touch ${debug_log}
 
 function log_debug() {
   echo `date` $1 >> ${debug_log}

--- a/pattern-2/bosh-release/jobs/wso2is_analytics_1/templates/ctl.erb
+++ b/pattern-2/bosh-release/jobs/wso2is_analytics_1/templates/ctl.erb
@@ -36,7 +36,6 @@ mkdir -p ${run_dir} ${log_dir}
 chown -R vcap:vcap ${run_dir} ${log_dir}
 
 debug_log=${log_dir}/${wso2_product}.log
-touch ${debug_log}
 
 function log_debug() {
   echo `date` $1 >> ${debug_log}

--- a/pattern-2/bosh-release/jobs/wso2is_analytics_2/templates/ctl.erb
+++ b/pattern-2/bosh-release/jobs/wso2is_analytics_2/templates/ctl.erb
@@ -36,7 +36,6 @@ mkdir -p ${run_dir} ${log_dir}
 chown -R vcap:vcap ${run_dir} ${log_dir}
 
 debug_log=${log_dir}/${wso2_product}.log
-touch ${debug_log}
 
 function log_debug() {
   echo `date` $1 >> ${debug_log}


### PR DESCRIPTION
## Purpose
> Currently, each job control script of the BOSH Releases of WSO2 Identity Server patterns a log file is unnecessarily created. This extra command is not created as the log file is automatically created if not exists, when `>>` (file append) command is used.

## Goals
> Remove extra Linux command step in each job control script.