### PR TITLE
Fix NFS job error after vm update in pattern-2

### DIFF
--- a/pattern-2/bosh-release/jobs/nfs_server/templates/ctl.erb
+++ b/pattern-2/bosh-release/jobs/nfs_server/templates/ctl.erb
@@ -52,7 +52,7 @@ log_debug "Kicking off ctl script as `whoami` with $1"
 dpkg -s nfs-kernel-server >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
   apt-get update
-  apt-get install nfs-kernel-server
+  apt-get install nfs-kernel-server -y
 fi
 
 # create the share directory and set permission


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/pivotal-cf-is/issues/64

## Goals
Fix the issue in the NFS job

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
PCF Ops Manager v2.4-build.131
tile version 12.0.8
bosh version 5.3.1-8366c6fd-2018-09-25T18:25:51Z
pcf version 12.0.8