### PR TITLE
Generalize health_check for pattern-1

### DIFF
--- a/pattern-1/bosh-release/jobs/health_check/spec
+++ b/pattern-1/bosh-release/jobs/health_check/spec
@@ -2,8 +2,14 @@
 name: health_check
 
 templates:
-    run.sh: bin/run
+    run.sh.erb: bin/run
 
 packages: []
 
-properties: {}
+properties:
+  health_check.endpoint:
+    description: Health Check endpoint
+  health_check.name:
+    description: Health Check name
+  health_check.status_code:
+    description: Health Check expected status code

--- a/pattern-1/bosh-release/jobs/health_check/templates/run.sh.erb
+++ b/pattern-1/bosh-release/jobs/health_check/templates/run.sh.erb
@@ -10,8 +10,8 @@ health_check() {
     then
         status_code=$(curl --write-out %{http_code} --silent --output /dev/null -k ${1})
 
-        # Check if requests to the health check endpoint produces  200 response
-        if [[ "$status_code" -ne 200 ]] ; then
+        # Check if requests to the health check endpoint produces a valid response
+        if [[ "$status_code" -ne <%= p("health_check.status_code") %> ]] ; then
             >&2 echo "WSO2 IS $2 produces an invalid response: $status_code"
             exit 1
         else
@@ -24,13 +24,13 @@ health_check() {
     fi
 }
 
-carbonHealthCheckEP="https://localhost:9443/carbon/admin/login.jsp"
+healthCheckEP=<%= p("health_check.endpoint") %>
 COUNTER=0
 
 # While the endpoint is not alive, and the server has been retrying for less than 3 minutes
 while [ ${isAlive} -eq 0 ]&&[ ${COUNTER} -lt 18 ]; do
     sleep 10s
-    health_check ${carbonHealthCheckEP} Carbon
+    health_check ${healthCheckEP} "<%= p("health_check.name") %>"
     let COUNTER=COUNTER+1
 done
 

--- a/pattern-1/tile/tile.yml
+++ b/pattern-1/tile/tile.yml
@@ -170,6 +170,10 @@ packages:
     static_ip: 1
     max_in_flight: 1
     properties:
+      health_check:
+        endpoint: "https://localhost:9443/carbon/admin/login.jsp"
+        name: "Identity Server Carbon"
+        status_code: 200
       wso2is:
         bps_ds:
           jdbc_url: (( .properties.bps_db_jdbc_url.value ))


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/pivotal-cf-is/issues/68

## Goals
Generalize the health_check for pattern-1

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
PCF Ops Manager v2.4-build.131
tile version 12.0.8
bosh version 5.3.1-8366c6fd-2018-09-25T18:25:51Z
pcf version 12.0.8