### PR TITLE
Change consent management configurations

### DIFF
--- a/pattern-1/bosh-release/jobs/wso2is/spec
+++ b/pattern-1/bosh-release/jobs/wso2is/spec
@@ -97,13 +97,47 @@ properties:
   wso2is.certs.value:
     description: Trusted CA certificate
 
-  cf.apps_domain:
-    description: Domain shared by the UAA and CF API eg 'bosh-lite.com'
-  cf.nats.host:
-    description: Hostname/IP of NATS
-  cf.nats.port:
-    description: Port that NATS listens on
-  cf.nats.username:
-    description: The user to use when authenticating with NATS
-  cf.nats.password:
-    description: The password to use when authenticating with NATS
+  wso2is.consent_mgt_conf.consent_db.jdbc_url:
+    description: Consent Datasource JDBC URL
+  wso2is.consent_mgt_conf.consent_db.username:
+    description: Consent Datasource username
+  wso2is.consent_mgt_conf.consent_db.password:
+    description: Consent Datasource password
+  wso2is.consent_mgt_conf.consent_db.driver:
+    description: Consent Datasource driver class name
+  wso2is.consent_mgt_conf.consent_db.query:
+    description: Consent Datasource validation query
+
+  wso2is.consent_mgt_conf.piicontroller:
+    description: PII Controller
+    default: change-me
+  wso2is.consent_mgt_conf.contact:
+    description: Contact
+    default: change-me
+  wso2is.consent_mgt_conf.email:
+    description: Email
+    default: change-me
+  wso2is.consent_mgt_conf.phone:
+    description: Phone
+    default: change-me
+  wso2is.consent_mgt_conf.piicontroller_url:
+    description: PII Controller URL
+    default: change-me
+  wso2is.consent_mgt_conf.country:
+    description: Country
+    default: change-me
+  wso2is.consent_mgt_conf.locality:
+    description: Locality
+    default: change-me
+  wso2is.consent_mgt_conf.region:
+    description: Region
+    default: change-me
+  wso2is.consent_mgt_conf.postoffice_box_number:
+    description: Post office box number
+    default: change-me
+  wso2is.consent_mgt_conf.postalcode:
+    description: Postal Code
+    default: change-me
+  wso2is.consent_mgt_conf.street_address:
+    description: Street Address
+    default: change-me

--- a/pattern-1/bosh-release/jobs/wso2is/templates/repository/conf/consent-mgt-config.xml.erb
+++ b/pattern-1/bosh-release/jobs/wso2is/templates/repository/conf/consent-mgt-config.xml.erb
@@ -18,22 +18,23 @@
     <DataSource>
         <!-- Include a data source name (jndiConfigName) from the set of data sources defined in master-datasources
         .xml -->
-        <Name>jdbc/WSO2IdentityDS</Name>
+        <!-- todo: make this optional. Make DataSource name configurable-->
+        <Name>jdbc/WSO2ConsentDS</Name>
     </DataSource>
     <PIIController>
-        <PiiController>change-me</PiiController>
-        <Contact>change-me</Contact>
-        <Email>change-me</Email>
-        <Phone>change-me</Phone>
+        <PiiController><%= p("wso2is.consent_mgt_conf.piicontroller") %></PiiController>
+        <Contact><%= p("wso2is.consent_mgt_conf.contact") %></Contact>
+        <Email><%= p("wso2is.consent_mgt_conf.email") %></Email>
+        <Phone><%= p("wso2is.consent_mgt_conf.phone") %></Phone>
         <OnBehalf>false</OnBehalf>
-        <PiiControllerUrl>change-me</PiiControllerUrl>
+        <PiiControllerUrl><%= p("wso2is.consent_mgt_conf.piicontroller_url") %></PiiControllerUrl>
         <Address>
-            <Country>change-me</Country>
-            <Locality>change-me</Locality>
-            <Region>change-me</Region>
-            <PostOfficeBoxNumber>change-me</PostOfficeBoxNumber>
-            <PostalCode>change-me</PostalCode>
-            <StreetAddress>change-me</StreetAddress>
+            <Country><%= p("wso2is.consent_mgt_conf.country") %></Country>
+            <Locality><%= p("wso2is.consent_mgt_conf.locality") %></Locality>
+            <Region><%= p("wso2is.consent_mgt_conf.region") %></Region>
+            <PostOfficeBoxNumber><%= p("wso2is.consent_mgt_conf.postoffice_box_number") %></PostOfficeBoxNumber>
+            <PostalCode><%= p("wso2is.consent_mgt_conf.postalcode") %></PostalCode>
+            <StreetAddress><%= p("wso2is.consent_mgt_conf.street_address") %></StreetAddress>
         </Address>
     </PIIController>
     <SearchLimits>

--- a/pattern-1/bosh-release/jobs/wso2is/templates/repository/conf/datasources/master-datasources.xml.erb
+++ b/pattern-1/bosh-release/jobs/wso2is/templates/repository/conf/datasources/master-datasources.xml.erb
@@ -91,6 +91,27 @@
             </definition>
         </datasource>
 
+        <datasource>
+            <name>WSO2_CONSENT_DS</name>
+            <description>The datasource used for consent data</description>
+            <jndiConfig>
+                <name>jdbc/WSO2ConsentDS</name>
+            </jndiConfig>
+            <definition type="RDBMS">
+                <configuration>
+                    <url><%= p("wso2is.consent_mgt_conf.consent_db.jdbc_url") %></url>
+                    <username><%= p("wso2is.consent_mgt_conf.consent_db.username") %></username>
+                    <password><%= p("wso2is.consent_mgt_conf.consent_db.password") %></password>
+                    <driverClassName><%= p("wso2is.consent_mgt_conf.consent_db.driver") %></driverClassName>
+                    <maxActive>50</maxActive>
+                    <maxWait>60000</maxWait>
+                    <testOnBorrow>true</testOnBorrow>
+                    <validationQuery><%= p("wso2is.consent_mgt_conf.consent_db.query") %></validationQuery>
+                    <validationInterval>30000</validationInterval>
+                </configuration>
+            </definition>
+        </datasource>
+
         <!-- For an explanation of the properties, see: http://people.apache.org/~fhanik/jdbc-pool/jdbc-pool.html -->
         <!--datasource>
             <name>SAMPLE_DATA_SOURCE</name>

--- a/pattern-1/tile/tile.yml
+++ b/pattern-1/tile/tile.yml
@@ -108,6 +108,76 @@ forms:
   - name: identity_db_credentials
     label: Identity Datasource Credentials
     type: simple_credentials
+
+- name: Consent Management Configurations
+  label: Consent Management Configurations
+  description: Consent Management Configurations
+  properties:
+  - name: consent_db_jdbc_url
+    type: string
+    label: Consent Datasource JDBC URL
+  - name: consent_db_driver
+    type: dropdown_select
+    label: Consent Datasource Driver Class Name
+    options:
+    - name: com.mysql.jdbc.Driver
+      label: com.mysql.jdbc.Driver
+      default: true
+    - name: com.microsoft.sqlserver.jdbc.SQLServerDriver
+      label: com.microsoft.sqlserver.jdbc.SQLServerDriver
+  - name: consent_db_query
+    type: string
+    label: Consent Datasource Validation Query
+  - name: consent_db_credentials
+    label: Consent Datasource Credentials
+    type: simple_credentials
+  - name: consent_mgt_config
+    label: Enable custom consent configurations
+    type: selector
+    configurable: true
+    default: default
+    option_templates:
+    - name: default_option
+      select_value: default
+      label: Use default PII Controller configurations
+    - name: custom_option
+      label: Customize PII Controller configurations
+      select_value: custom
+      property_blueprints:
+      - name: piicontroller
+        type: string
+        label: PII Controller
+      - name: contact
+        type: string
+        label: Contact
+      - name: email
+        type: string
+        label: Email
+      - name: phone
+        type: string
+        label: Phone
+      - name: piicontroller_url
+        type: string
+        label: PII Controller URL
+      - name: address_country
+        type: string
+        label: Country
+      - name: address_locality
+        type: string
+        label: Locality
+      - name: address_region
+        type: string
+        label: Region
+      - name: address_postoffice_box_number
+        type: string
+        label: Post-Office box number
+      - name: address_postalcode
+        type: string
+        label: Postal Code
+      - name: address_street
+        type: string
+        label: Street Address
+
 - name: Certificate Information
   label: Trusted CA certificate
   description: Trusted CA certificate
@@ -197,6 +267,25 @@ packages:
           query: (( .properties.identity_db_query.value ))
           username: (( .properties.identity_db_credentials.identity ))
           password: (( .properties.identity_db_credentials.password ))
+        consent_mgt_conf:
+          consent_db:
+            jdbc_url: (( .properties.consent_db_jdbc_url.value ))
+            driver: (( .properties.consent_db_driver.value ))
+            query: (( .properties.consent_db_query.value ))
+            username: (( .properties.consent_db_credentials.identity ))
+            password: (( .properties.consent_db_credentials.password ))
+          piicontroller: (( .properties.consent_mgt_config.custom_option.piicontroller.value ))
+          contact: (( .properties.consent_mgt_config.custom_option.contact.value ))
+          email: (( .properties.consent_mgt_config.custom_option.email.value ))
+          phone: (( .properties.consent_mgt_config.custom_option.phone.value ))
+          piicontroller_url: (( .properties.consent_mgt_config.custom_option.piicontroller_url.value ))
+          country: (( .properties.consent_mgt_config.custom_option.address_country.value ))
+          locality: (( .properties.consent_mgt_config.custom_option.address_locality.value ))
+          region: (( .properties.consent_mgt_config.custom_option.address_region.value ))
+          postoffice_box_number: (( .properties.consent_mgt_config.custom_option.address_postoffice_box_number.value ))
+          postalcode: (( .properties.consent_mgt_config.custom_option.address_postalcode.value ))
+          street_address: (( .properties.consent_mgt_config.custom_option.address_street.value ))
+
       route_registrar:
         routes:
         - name: wso2is


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/pivotal-cf-is/issues/88

## Goals

- Add consent-mgt configurations to the tile and make it optional to customize.
- Add a separate datasource form for Consent Management.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
PCF Ops Manager v2.4-build.131
tile version 13.2.0
bosh version 5.5.1-7850ac98-2019-05-21T22:28:36Z
pcf version 13.2.0
 
## Learning
Selector example
https://github.com/cf-platform-eng/tile-generator/blob/64b3cdc6beb92963cf5a4afe9589736bf03cce76/sample/tile.yml#L76-L120