### PR TITLE
Enable health-check API

### DIFF
--- a/pattern-1/bosh-release/jobs/wso2is/spec
+++ b/pattern-1/bosh-release/jobs/wso2is/spec
@@ -12,6 +12,7 @@ templates:
   repository/conf/tomcat/context.xml: repository/conf/tomcat/context.xml
   repository/conf/carbon.xml.erb: repository/conf/carbon.xml
   repository/conf/consent-mgt-config.xml.erb: repository/conf/consent-mgt-config.xml
+  repository/conf/health-check-config.xml: repository/conf/health-check-config.xml
   repository/conf/log4j.properties: repository/conf/log4j.properties
   repository/conf/registry.xml.erb: repository/conf/registry.xml
   repository/conf/user-mgt.xml.erb: repository/conf/user-mgt.xml

--- a/pattern-1/bosh-release/jobs/wso2is/templates/repository/conf/health-check-config.xml
+++ b/pattern-1/bosh-release/jobs/wso2is/templates/repository/conf/health-check-config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+ -->
+
+<Server xmlns="http://wso2.org/projects/carbon/carbon.xml">
+
+    <CarbonHealthCheckConfigs>
+
+        <Enable>true</Enable>
+
+        <HealthCheckers>
+            <HealthChecker name="DataSourceHealthChecker" orderId="97" enable="true">
+                <!--<Property name="monitored.datasources">jdbc/WSO2CarbonDB,jdbc/WSO2MetricsDB,jdbc/WSO2UMDB</Property>-->
+                <Property name="pool.usage.limit.percentage">80</Property>
+            </HealthChecker>
+            <HealthChecker name="SuperTenantUSHealthChecker" orderId="98" enable="true">
+                <!--<Property name="monitored.user.stores">primary,sec</Property>-->
+            </HealthChecker>
+        </HealthCheckers>
+
+    </CarbonHealthCheckConfigs>
+</Server>

--- a/pattern-1/ops_update.sh
+++ b/pattern-1/ops_update.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+#
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+
+# exit immediately if a command exits with a non-zero status
+set -e
+
+usage() { echo "Usage: $0 [-b <branch name>] [-u <username>] [-p <password>]" 1>&2; exit 1; }
+
+while getopts ":b:u:p:" o; do
+    case "${o}" in
+        b)
+            branch=${OPTARG}
+            ;;
+        u)
+            username=${OPTARG}
+            ;;
+        p)
+            password=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${branch}" ] || [ -z "${username}" ] || [ -z "${password}" ]; then
+    usage
+fi
+
+echo "Pulling changes from branch..."
+git fetch
+git checkout ${branch}
+# Check for changes
+upstream=${1:-'@{u}'}
+local=$(git rev-parse @)
+remote=$(git rev-parse "$upstream")
+base=$(git merge-base @ "$upstream")
+if [ ${local} = ${remote} ]; then
+    # up-to-date
+    exit 0
+elif [ ${local} = ${base} ]; then
+    git pull origin ${branch}
+elif [ ${remote} = ${base} ]; then
+    echo "Changes made in local branch. Please revert changes and retry."
+    exit 1
+else
+    echo "Local repository Diverged. Please revert changes and retry."
+    exit 1
+fi
+
+echo "Updating tile..."
+/bin/bash update.sh
+rc=$?;
+if [[ ${rc} != 0 ]]; then
+    echo "Error occurred while updating tile. Terminating with exit code $rc"
+    exit ${rc};
+fi
+
+echo "Obtaining access token..."
+response=$(curl -s -k -H 'Accept: application/json;charset=utf-8' -d 'grant_type=password' -d "username=$username" -d "password=$password" -u 'opsman:' https://localhost/uaa/oauth/token)
+access_token=$(echo ${response} | sed -nE 's/.*"access_token":"(.*)","token.*/\1/p')
+if [ -z "$access_token" ]
+then
+    status_code=$(curl --write-out %{http_code} --output /dev/null -s -k -H 'Accept: application/json;charset=utf-8' -d 'grant_type=password' -d "username=$username" -d "password=$password" -u 'opsman:' https://localhost/uaa/oauth/token)
+    echo "Access token could not be obtained. Status code: $status_code"
+    exit 1
+fi
+
+echo "Uploading new tile..."
+cd tile/product
+product_dir=$(pwd)
+: ${product_tile:="wso2apim-tile-0.0.*.pivotal"}
+
+# capture the exact product distribution identifiers
+product_tile=$(ls ${product_tile})
+tile_filepath=${product_dir}/${product_tile}
+
+status_code=$(curl --write-out %{http_code} --output /dev/null -H "Authorization: Bearer $access_token" 'https://localhost/api/products' -F "product[file]=@$tile_filepath"  -X POST -k)
+if [ ${status_code} = 200 ]; then
+    echo "Updated tile successfully added to Ops Manager"
+else
+    echo "Error while adding tile to Ops Manager. Status code ${status_code}"
+fi

--- a/pattern-1/ops_update.sh
+++ b/pattern-1/ops_update.sh
@@ -88,7 +88,7 @@ fi
 echo "Uploading new tile..."
 cd tile/product
 product_dir=$(pwd)
-: ${product_tile:="wso2apim-tile-0.0.*.pivotal"}
+: ${product_tile:="wso2is*.pivotal"}
 
 # capture the exact product distribution identifiers
 product_tile=$(ls ${product_tile})

--- a/pattern-1/tile/tile.yml
+++ b/pattern-1/tile/tile.yml
@@ -237,7 +237,7 @@ packages:
     max_in_flight: 1
     properties:
       health_check:
-        endpoint: "https://localhost:9443/carbon/admin/login.jsp"
+        endpoint: "https://localhost:9443/api/health-check/v1.0/health"
         name: "Identity Server Carbon"
         status_code: 200
       wso2is:


### PR DESCRIPTION
## Purpose
Resolves #91

## Goals
Currently, the server health is monitored using the Login URL endpoint[1] instead of the health-check endpoint[2].

1. https://localhost:9443/carbon/admin/login.jsp
2. https://localhost:9443/api/health-check/v1.0/health

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
PCF Ops Manager v2.4-build.131
tile version 13.2.0
bosh version 5.5.1-7850ac98-2019-05-21T22:28:36Z
pcf version 13.2.0
 
## Learning
https://docs.wso2.com/display/ADMIN44x/Monitoring+Server+Health